### PR TITLE
Session - User object link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let options = { // Defaults (excluding client)
         user:{ //Optional, Links newly created session node to another node within neo4j
                label: "User", //Optional, label of the node to be matched
                id: "username", //Required, property the user should be matched by, supply data under the same key in session object
-               relationshipType: "has_session" //Optional, label the created relationship will take
+               relType: "has_session" //Optional, label the created relationship will take
         }
 }
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ let options = { // Defaults (excluding client)
         ttl: 86400, // Optional, set a default ttl (time to live).
         disableTTL: false, //Optional, Disables TTL functionallity
         disableTouch: false, // Optional, Disables Touch functionallty
+        user:{ //Optional, Links newly created session node to another node within neo4j
+                label: "User", //Required, label of the node to be matched
+                idProperty: "username", //Required, property for linking user node, data should be supplied under the same key in session object
+                relationshipType: "has_session" //Optional, label the created relationship will take
+        }
 }
 
 let store = new Neo4jStore({ options ) })

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ let options = { // Defaults (excluding client)
         disableTTL: false, //Optional, Disables TTL functionallity
         disableTouch: false, // Optional, Disables Touch functionallty
         user:{ //Optional, Links newly created session node to another node within neo4j
-                label: "User", //Optional, label of the node to be matched
-                id: "username", //Required, property the user should be matched by, supply data under the same key in session object
-                relationshipType: "has_session" //Optional, label the created relationship will take
+               label: "User", //Optional, label of the node to be matched
+               id: "username", //Required, property the user should be matched by, supply data under the same key in session object
+               relationshipType: "has_session" //Optional, label the created relationship will take
         }
 }
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let options = { // Defaults (excluding client)
         user:{ //Optional, Links newly created session node to another node within neo4j
                label: "User", //Optional, label of the node to be matched
                id: "username", //Required, property the user should be matched by, supply data under the same key in session object
-               relType: "has_session" //Optional, label the created relationship will take
+               relType: "has_session" //Required, label the created relationship will take
         }
 }
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ let options = { // Defaults (excluding client)
         }
 }
 
-let store = new Neo4jStore({ options ) })
+let store = new Neo4jStore({ options })
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ let options = { // Defaults (excluding client)
         disableTTL: false, //Optional, Disables TTL functionallity
         disableTouch: false, // Optional, Disables Touch functionallty
         user:{ //Optional, Links newly created session node to another node within neo4j
-                label: "User", //Required, label of the node to be matched
-                idProperty: "username", //Required, property for linking user node, data should be supplied under the same key in session object
+                label: "User", //Optional, label of the node to be matched
+                id: "username", //Required, property the user should be matched by, supply data under the same key in session object
                 relationshipType: "has_session" //Optional, label the created relationship will take
         }
 }

--- a/lib/connect-neo4j.js
+++ b/lib/connect-neo4j.js
@@ -17,6 +17,17 @@ module.exports = function (session) {
       this._ttl = options.ttl || 86400 // One day in seconds.
       this.disableTTL = options.disableTTL || false
       this.disableTouch = options.disableTouch || false
+      if(options.user){
+      	if(!options.user.label){
+      		throw new Error('A user object is present, but no node label is supplied');
+      	}
+      	this.userLabel = options.user.label
+      	if(!options.user.idProperty){
+      		throw new Error('A user object is present, but no identifying property is supplied');
+      	}
+      	this.userIdProperty = options.user.idProperty
+      	this.userRelationshipType = options.user.relationshipType == null ? '' : ':' + options.user.relationshipType
+      }
     }
 
     get(sid, cb = noop) {
@@ -69,13 +80,20 @@ module.exports = function (session) {
       }
 
       let sess = this.client.session()
-      sess
-        .run(
-          `MERGE (s:${this.nodeLabel} {sid: $sid}) ON CREATE SET s.data = $data, s.expires = $expires ON MATCH SET s.data = $data`,
-          { sid: key, data, expires }
-        )
-        .then(() => cb(null, 'OK'))
-        .catch(cb)
+      sess.run(`MERGE (s:${this.nodeLabel} {sid: $sid}) 
+      	ON CREATE SET s.data = $data, s.expires = $expires 
+      	ON MATCH SET s.data = $data`,  
+      	{ sid: key, data, expires }
+      ).then(async () => {
+      	if(this.userLabel && session[this.userIdProperty]){
+      		await sess.run(`MATCH (s:${this.nodeLabel}{sid:$sid})
+      		OPTIONAL MATCH (n:${this.userLabel}{${this.userIdProperty}:$${this.userIdProperty}})
+      		MERGE (s)<-[${this.userRelationshipType}]-(n)`,
+      		{sid: key, this.userIdProperty: session[this.userIdProperty]});
+      	}
+      }).then(() => {cb(null, 'OK')})
+      .catch(cb)
+      .finally(() => {sess.close()});
     }
     touch(sid, session, cb = noop) {
       if (this.disableTouch || this.disableTTL) return cb(null, null)

--- a/lib/connect-neo4j.js
+++ b/lib/connect-neo4j.js
@@ -82,7 +82,7 @@ module.exports = function (session) {
         ON MATCH SET s.data = $data`,  
         { sid: key, data, expires }
       ).then(async () => {
-        if(this.userLabel && session[this.userIdProperty]){
+        if(this.userLabel && session[this.userId]){
           let opts = {sid: key};
           opts[this.userId] = session[this.userId];
           await sess.run(`MATCH (s:${this.nodeLabel}{sid:$sid})

--- a/lib/connect-neo4j.js
+++ b/lib/connect-neo4j.js
@@ -18,7 +18,7 @@ module.exports = function (session) {
       this.disableTTL = options.disableTTL || false
       this.disableTouch = options.disableTouch || false
       if(options.user){
-        this.userLabel = options.user.label == null ? '' : options.user.label
+        this.userLabel = options.user.label == null ? '' : ":" + options.user.label
         if(!options.user.id){
           throw new Error('A user object is present, but no identifying property is supplied');
         }
@@ -86,7 +86,7 @@ module.exports = function (session) {
           let opts = {sid: key};
           opts[this.userId] = session[this.userId];
           await sess.run(`MATCH (s:${this.nodeLabel}{sid:$sid})
-          OPTIONAL MATCH (n:${this.userLabel}{${this.userId}:$${this.userId}})
+          OPTIONAL MATCH (n${this.userLabel}{${this.userId}:$${this.userId}})
           MERGE (s)<-[${this.userRelType}]-(n)`,
           opts);
         }

--- a/lib/connect-neo4j.js
+++ b/lib/connect-neo4j.js
@@ -18,15 +18,12 @@ module.exports = function (session) {
       this.disableTTL = options.disableTTL || false
       this.disableTouch = options.disableTouch || false
       if(options.user){
-      	if(!options.user.label){
-      		throw new Error('A user object is present, but no node label is supplied');
-      	}
-      	this.userLabel = options.user.label
-      	if(!options.user.idProperty){
-      		throw new Error('A user object is present, but no identifying property is supplied');
-      	}
-      	this.userIdProperty = options.user.idProperty
-      	this.userRelationshipType = options.user.relationshipType == null ? '' : ':' + options.user.relationshipType
+        this.userLabel = options.user.label == null ? '' : options.user.label
+        if(!options.user.id){
+          throw new Error('A user object is present, but no identifying property is supplied');
+        }
+        this.userId = options.user.id
+        this.userRelType = options.user.relType == null ? '' : ':' + options.user.relType
       }
     }
 
@@ -81,18 +78,18 @@ module.exports = function (session) {
 
       let sess = this.client.session()
       sess.run(`MERGE (s:${this.nodeLabel} {sid: $sid}) 
-      	ON CREATE SET s.data = $data, s.expires = $expires 
-      	ON MATCH SET s.data = $data`,  
-      	{ sid: key, data, expires }
+        ON CREATE SET s.data = $data, s.expires = $expires 
+        ON MATCH SET s.data = $data`,  
+        { sid: key, data, expires }
       ).then(async () => {
-      	if(this.userLabel && session[this.userIdProperty]){
+        if(this.userLabel && session[this.userIdProperty]){
           let opts = {sid: key};
-          opts[this.userIdProperty] = session[this.userIdProperty];
-      		await sess.run(`MATCH (s:${this.nodeLabel}{sid:$sid})
-      		OPTIONAL MATCH (n:${this.userLabel}{${this.userIdProperty}:$${this.userIdProperty}})
-      		MERGE (s)<-[${this.userRelationshipType}]-(n)`,
-      		opts);
-      	}
+          opts[this.userId] = session[this.userId];
+          await sess.run(`MATCH (s:${this.nodeLabel}{sid:$sid})
+          OPTIONAL MATCH (n:${this.userLabel}{${this.userId}:$${this.userId}})
+          MERGE (s)<-[${this.userRelType}]-(n)`,
+          opts);
+        }
       }).then(() => {cb(null, 'OK')})
       .catch(cb)
       .finally(() => {sess.close()});

--- a/lib/connect-neo4j.js
+++ b/lib/connect-neo4j.js
@@ -86,10 +86,12 @@ module.exports = function (session) {
       	{ sid: key, data, expires }
       ).then(async () => {
       	if(this.userLabel && session[this.userIdProperty]){
+          let opts = {sid: key};
+          opts[this.userIdProperty] = session[this.userIdProperty];
       		await sess.run(`MATCH (s:${this.nodeLabel}{sid:$sid})
       		OPTIONAL MATCH (n:${this.userLabel}{${this.userIdProperty}:$${this.userIdProperty}})
       		MERGE (s)<-[${this.userRelationshipType}]-(n)`,
-      		{sid: key, this.userIdProperty: session[this.userIdProperty]});
+      		opts);
       	}
       }).then(() => {cb(null, 'OK')})
       .catch(cb)

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "connect-neo4j",
-  "version": "1.0.1",
-  "description": "Neo4j Session store",
+  "name": "connect-neo4j-user",
+  "version": "1.0.0",
+  "description": "Neo4j Session store - with user connectivity",
   "main": "index.js",
   "scripts": {
     "test": "tape tests/**/*.js"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:MaxAndersson/connect-neo4j.git"
+    "url": "git@github.com:darkmattur/connect-neo4j.git"
   },
   "keywords": [
     "express",
@@ -16,12 +16,12 @@
     "store",
     "neo4j"
   ],
-  "author": "Max Andersson",
+  "author": "Matus Lecky",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/MaxAndersson/connect-neo4j/issues"
+    "url": "https://github.com/darkmattur/connect-neo4j/issues"
   },
-  "homepage": "https://github.com/MaxAndersson/connect-neo4j#readme",
+  "homepage": "https://github.com/darkmattur/connect-neo4j#readme",
   "dependencies": {
     "connect-neo4j": "https://github.com/MaxAndersson/connect-neo4j/releases/download/1.0.0/connect-neo4j-1.0.0.tgz"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-neo4j-user",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Neo4j Session store - with user connectivity",
   "main": "index.js",
   "scripts": {
@@ -22,9 +22,6 @@
     "url": "https://github.com/darkmattur/connect-neo4j/issues"
   },
   "homepage": "https://github.com/darkmattur/connect-neo4j#readme",
-  "dependencies": {
-    "connect-neo4j": "https://github.com/MaxAndersson/connect-neo4j/releases/download/1.0.0/connect-neo4j-1.0.0.tgz"
-  },
   "devDependencies": {
     "express-session": "^1.17.2",
     "neo4j-driver": "^4.3.3",


### PR DESCRIPTION
Before, session nodes were simply being created and left unlinked to other nodes, with no way of knowing which user they belonged to. With this change, a user node is matched and then linked to a session node on session creation.